### PR TITLE
Gpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ name = "bmpf-rs"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "gpoint",
  "ziggurat-rs",
 ]
 
@@ -107,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "gpoint"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00f1d62d57408109a871dd9e12b76645ec4284406d5ec838d277777ef1ef6c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +127,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "once_cell_polyfill"

--- a/bmpf-rs/Cargo.toml
+++ b/bmpf-rs/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 ziggurat-rs = { path = "../ziggurat-rs" }
+gpoint = "0.2"
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/bmpf-rs/examples/bpf.rs
+++ b/bmpf-rs/examples/bpf.rs
@@ -1,5 +1,6 @@
 use bmpf_rs::types::BpfState;
 use clap::Parser;
+use gpoint::GPoint;
 use std::{
     f64::consts::PI,
     fs::File,
@@ -98,7 +99,7 @@ fn main() {
                 report = t_ms - t_last >= state.report_particles;
             }
             t = t0;
-            print!("{} {}", state.vehicle.x, state.vehicle.y);
+            print!("{} {}", GPoint(state.vehicle.x), GPoint(state.vehicle.y));
             state.bpf_step(t, dt, report);
             if report {
                 t_last = t_ms;

--- a/bmpf-rs/examples/vehicle.rs
+++ b/bmpf-rs/examples/vehicle.rs
@@ -1,4 +1,5 @@
 use bmpf_rs::types::VehicleState;
+use gpoint::GPoint;
 
 fn run() {
     let mut t = 0.0f64;
@@ -14,7 +15,13 @@ fn run() {
         let imu = vehicle.imu_measure(dt);
         println!(
             "{} {} {} {} {} {} {}",
-            msec, vehicle.posn.x, vehicle.posn.y, gps.x, gps.y, imu.r, imu.t
+            msec,
+            GPoint(vehicle.posn.x),
+            GPoint(vehicle.posn.y),
+            GPoint(gps.x),
+            GPoint(gps.y),
+            GPoint(imu.r),
+            GPoint(imu.t)
         );
         t += dt;
     }

--- a/bmpf-rs/src/types.rs
+++ b/bmpf-rs/src/types.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     uniform,
 };
+use gpoint::GPoint;
 use std::{cmp::Ordering, f64::consts::PI, fs::OpenOptions, io::Write};
 
 #[derive(Default, Clone, Copy)]
@@ -332,7 +333,7 @@ impl BpfState {
             for i in 0..self.nparticles {
                 tweight += self.pstates[self.which_particle as usize].data[i].weight;
             }
-            assert!(tweight > 0.00001, "{} < 0.00001", tweight);
+            assert!(tweight > 0.00001, "{} < 0.00001", GPoint(tweight));
         }
         tweight = 0.0;
         for i in 0..self.nparticles {
@@ -350,10 +351,13 @@ impl BpfState {
             #[cfg(feature = "debug")]
             {
                 if i == 0 {
-                    eprintln!("gp={} ip={} w={}", gp, ip, w);
+                    eprintln!("gp={} ip={} w={}", GPoint(gp), GPoint(ip), GPoint(w));
                     eprintln!(
                         "gps=({} {}), imu=(r={}, t={})",
-                        self.gps.x, self.gps.y, self.imu.r, self.imu.t
+                        GPoint(self.gps.x),
+                        GPoint(self.gps.y),
+                        GPoint(self.imu.r),
+                        GPoint(self.imu.t)
                     );
                 }
             }
@@ -397,7 +401,7 @@ impl BpfState {
                     .posn
                     .y;
                 let w = self.pstates[self.which_particle as usize].data[i].weight;
-                if let Err(e) = writeln!(file, "{} {} {}", px, py, w) {
+                if let Err(e) = writeln!(file, "{} {} {}", GPoint(px), GPoint(py), GPoint(w)) {
                     eprintln!("Could not write to benchtmp/particles-{}.dat: {}", t, e)
                 }
             }
@@ -445,45 +449,61 @@ impl BpfState {
         {
             print!(
                 "  {} {} {}",
-                best_weight,
-                self.pstates[self.which_particle as usize].data[best]
-                    .state
-                    .posn
-                    .x,
-                self.pstates[self.which_particle as usize].data[best]
-                    .state
-                    .posn
-                    .y,
+                GPoint(best_weight),
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[best]
+                        .state
+                        .posn
+                        .x
+                ),
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[best]
+                        .state
+                        .posn
+                        .y
+                ),
             );
             print!(
                 "  {} {} {}",
-                worst_weight,
-                self.pstates[self.which_particle as usize].data[worst]
-                    .state
-                    .posn
-                    .x,
-                self.pstates[self.which_particle as usize].data[worst]
-                    .state
-                    .posn
-                    .y,
+                GPoint(worst_weight),
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[worst]
+                        .state
+                        .posn
+                        .x
+                ),
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[worst]
+                        .state
+                        .posn
+                        .y
+                ),
             );
         }
         #[cfg(not(feature = "diagnostic-print"))]
         {
             print!(
                 "  {} {}",
-                self.pstates[self.which_particle as usize].data[best]
-                    .state
-                    .posn
-                    .x,
-                self.pstates[self.which_particle as usize].data[best]
-                    .state
-                    .posn
-                    .y
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[best]
+                        .state
+                        .posn
+                        .x
+                ),
+                GPoint(
+                    self.pstates[self.which_particle as usize].data[best]
+                        .state
+                        .posn
+                        .y
+                )
             );
         }
         if !self.best_particle {
-            print!("  {} {}", est_state.posn.x, est_state.posn.y);
+            print!(
+                "  {} {}",
+                GPoint(est_state.posn.x),
+                GPoint(est_state.posn.y)
+            );
         }
     }
 }

--- a/bmpf-rs/src/types.rs
+++ b/bmpf-rs/src/types.rs
@@ -365,7 +365,7 @@ impl BpfState {
             tweight += w;
         }
         #[cfg(feature = "debug")]
-        assert!(tweight > 0.00001, "{} < 0.00001", tweight);
+        assert!(tweight > 0.00001, "{} < 0.00001", GPoint(tweight));
         let invtweight = 1.0 / tweight;
         for i in 0..self.nparticles {
             self.pstates[self.which_particle as usize].data[i].weight *= invtweight;

--- a/ziggurat-rs/Cargo.toml
+++ b/ziggurat-rs/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# gpoint = "0.2"
+
+# [build-dependencies]
+# gpoint = "0.2"
 
 [features]
 default = []

--- a/ziggurat-rs/examples/normaltest.rs
+++ b/ziggurat-rs/examples/normaltest.rs
@@ -1,7 +1,6 @@
 #![feature(float_erf)]
-
+use gpoint::GPoint;
 use std::f64::consts::FRAC_1_SQRT_2;
-
 use ziggurat_rs::Ziggurat;
 
 const NV: usize = 10000000;
@@ -53,6 +52,6 @@ fn main() {
     (0..NB).for_each(|i| {
         let x = binwidth * (i as f64 + 0.5) + minv;
         let expected = a * (x * x * b).exp();
-        println!("{:.7} {} {:.7}", x, bin[i], expected);
+        println!("{} {} {}", GPoint(x), bin[i], GPoint(expected));
     });
 }

--- a/ziggurat-rs/examples/polytest.rs
+++ b/ziggurat-rs/examples/polytest.rs
@@ -1,4 +1,5 @@
 use core::f64::{self};
+use gpoint::GPoint;
 use ziggurat_rs::Ziggurat;
 
 static NV: usize = 10000000;
@@ -36,6 +37,6 @@ fn main() {
         let x0 = binwidth * i as f64;
         let x1 = x0 + binwidth;
         let a = (1.0f64 - x0).powi(PN + 1) - (1.0f64 - x1).powi(PN + 1);
-        println!("{:.7} {} {:.7}", x, bin[i], NV as f64 * a);
+        println!("{} {} {}", GPoint(x), bin[i], GPoint(NV as f64 * a));
     });
 }


### PR DESCRIPTION
Uses gpoint crate to print `f64`s as if they were printing with C's `printf("%g")`

I do not think this is ultimately necessary to use, but I was curious if I could produce results matching the C output exactly, and with this crate I was able to.

Unfortunately, neither the C or Rust output will converge with 100 particles optimal resampling. Perhaps I need to run multiple instances and find a lucky run?

I am unsure how to reproduce the outputs of the paper.